### PR TITLE
Load cl for using lexical-let*

### DIFF
--- a/javap-mode.el
+++ b/javap-mode.el
@@ -22,6 +22,11 @@
 ;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 ;; THE SOFTWARE.
 
+;;; Code:
+
+(eval-when-compile
+  (require 'cl))
+
 (defconst javap-font-lock-keywords
   (eval-when-compile
     `(


### PR DESCRIPTION
There are following byte-compile warnings. This change fixes them.

```
In javap-buffer:
javap-mode.el:88:4:Warning: `(b-name (file-name-nondirectory
    (buffer-file-name)))' is a malformed function
javap-mode.el:90:19:Warning: reference to free variable `b-name'
javap-mode.el:92:39:Warning: reference to free variable `new-b-name'
javap-mode.el:98:41:Warning: reference to free variable `old-buf'
javap-mode.el:100:11:Warning: reference to free variable `new-buf'
javap-mode.el:110:28:Warning: reference to free variable `done'

In end of data:
javap-mode.el:120:1:Warning: the following functions are not known to be defined: lexical-let*,
    b-name, new-b-name, new-buf, old-buf, done
```
