### PR TITLE
fix autoload cookies

### DIFF
--- a/javap-mode.el
+++ b/javap-mode.el
@@ -72,7 +72,7 @@
 (defvar javap-mode-syntax-table′ (make-syntax-table)
   "Syntax table for use in javap-mode.")
 
- ;;;###autoload
+;;;###autoload
 (define-derived-mode javap-mode fundamental-mode "javap"
   "A major mode for viewing javap files."
   :syntax-table javap-mode-syntax-table′
@@ -83,6 +83,7 @@
   (set (make-local-variable 'comment-start-skip) "#")
   (set (make-local-variable 'font-lock-defaults) '(javap-font-lock-keywords)))
 
+;;;###autoload
 (defun javap-buffer ()
   "run javap on contents of buffer"
   (interactive)
@@ -109,6 +110,7 @@
       (javap-mode)
       (local-set-key [(q)] done))))
 
+;;;###autoload
 (add-hook 'find-file-hook
           (lambda (&rest args)
             (if (string= ".class" (substring (buffer-file-name) -6 nil))


### PR DESCRIPTION
Add autoload cookies for `find-file-hook` and `javap-buffer`. Fix the cookie in javap-mode.

These cookies make emacs load up the find-file-hook and the mode-functions at startup. This makes javap-mode work correctly when the user simply installs the package without forcing the user to require or otherwise configure the package.

This matches what various other packages do with `auto-mode-alist`. See http://www.lunaryorn.com/2014/07/02/autoloads-in-emacs-lisp.html for more information.
